### PR TITLE
Bump R to 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: version.compare
 Title: Compares the Results of Running Code in Different Installed Versions of R
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: "Andrie de Vries <adevries@microsoft.com> [aut, cre]"
-Date: 2017-03-22
+Date: 2021-09-07
 Description: Allows you to run R code in different versions of R and compare
     results. In addition, provides an easy mechanism to run a modified version of
     the Urbanek benchmark tests.
@@ -12,7 +12,7 @@ URL: http://www.github.com/andrie/version.compare
 BugReports: http://www.github.com/andrie/version.compare/issues
 LazyData: true
 Depends:
-    R (>= 3.0.0),
+    R (>= 4.0.0),
 Imports:
     MASS,
     ggplot2,

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ rscript <- findRscript()
 rscript <- switch(
   Sys.info()[["sysname"]],
   Windows = c(
-    "c:/program files/RRO/R-3.1.1/bin/x64/Rscript.exe",
-    "c:/program files/R/R-3.1.1/bin/x64/Rscript.exe"
+    "c:/program files/RRO/R-4.0.2/bin/x64/Rscript.exe",
+    "c:/program files/R/R-4.0.2/bin/x64/Rscript.exe"
   ),
   Linux = c(
-    "/usr/lib64/RRO-8.0/R-3.1.1/lib/R/bin/Rscript",
+    "/usr/lib64/RRO-8.0/R-4.0.2/lib/R/bin/Rscript",
     "/usr/lib/R/bin/Rscript"
   )
 )


### PR DESCRIPTION
This PR supports R >= 4.0.0.

Performance results on my laptop(2 cores, 4 threads) are as follows;
```
> kable(test.results)


|                             | R-4.0.2 (1 thread)| Microsoft R Open-4.0.2 (1 thread)| Microsoft R Open-4.0.2 (8 threads)| Microsoft R Open-4.0.2 (4 threads)|
|:----------------------------|------------------:|---------------------------------:|----------------------------------:|----------------------------------:|
|Matrix multiplication        |             183.77|                              9.10|                               6.67|                               6.80|
|Cholesky factorization       |              27.28|                              1.59|                               1.21|                               1.22|
|QR decomposition             |               5.17|                              3.36|                               3.90|                               3.88|
|Singular value decomposition |              60.86|                              8.50|                               7.42|                               7.33|
|Principal component analysis |              50.78|                              8.54|                               7.41|                               7.28|
|Linear discriminant analysis |              13.42|                              3.59|                               3.26|                               3.28|
> plot(test.results, theme_size=8, main='Elapsed time')
> kable(urbanekPerformance(test.results), digits=2)


|                             | R-4.0.2 (1 thread)| Microsoft R Open-4.0.2 (1 thread)| Microsoft R Open-4.0.2 (8 threads)| Microsoft R Open-4.0.2 (4 threads)|
|:----------------------------|------------------:|---------------------------------:|----------------------------------:|----------------------------------:|
|Matrix multiplication        |                  1|                             20.19|                              27.55|                              27.02|
|Cholesky factorization       |                  1|                             17.16|                              22.55|                              22.36|
|QR decomposition             |                  1|                              1.54|                               1.33|                               1.33|
|Singular value decomposition |                  1|                              7.16|                               8.20|                               8.30|
|Principal component analysis |                  1|                              5.95|                               6.85|                               6.98|
|Linear discriminant analysis |                  1|                              3.74|                               4.12|                               4.09|
> plot(urbanekPerformance(test.results), theme_size=8, main='Relative Performance')
> 
```

![cran402-mran402](https://user-images.githubusercontent.com/6870447/132354403-042619cd-8d51-4547-b9b5-f6093099f001.png)



#### Remark
- Testcases are not performed.
- Vignettes and Documentation are not updated.